### PR TITLE
add support for diffbot version 3

### DIFF
--- a/src/main/java/com/diffbot/api/scala/Version.java
+++ b/src/main/java/com/diffbot/api/scala/Version.java
@@ -13,5 +13,9 @@ public enum Version {
 	/**
 	 * Version 2.
 	 */
-	v2
+	v2,
+	/**
+	 * Version 3.
+	 */
+	v3
 }

--- a/src/main/java/com/diffbot/api/scala/Version.java
+++ b/src/main/java/com/diffbot/api/scala/Version.java
@@ -5,8 +5,8 @@ package com.diffbot.api.scala;
  */
 public enum Version {
 	/**
-	 * Version 1, please use {@link Version#v2} instead.
-	 * @deprecated Use {@link Version#v2} instead.
+	 * Version 1, please use {@link Version#v3} instead.
+	 * @deprecated Use {@link Version#v3} instead.
 	 */
 	@Deprecated
 	v1,

--- a/src/main/java/com/diffbot/api/scala/Version.java
+++ b/src/main/java/com/diffbot/api/scala/Version.java
@@ -11,8 +11,10 @@ public enum Version {
 	@Deprecated
 	v1,
 	/**
-	 * Version 2.
+	 * Version 2, please use {@link Version#v3} instead.
+	 * @deprecated Use {@link Version#v3} instead.
 	 */
+	@Deprecated
 	v2,
 	/**
 	 * Version 3.

--- a/src/main/scala/com/diffbot/api/scala/Implicits.scala
+++ b/src/main/scala/com/diffbot/api/scala/Implicits.scala
@@ -15,7 +15,7 @@ object Implicits {
   implicit val timeout: DiffbotTimeout = DiffbotTimeout(125.seconds)
 
   /**
-   * The default Diffbot API to use, v2.
+   * The default Diffbot API to use, v3.
    */
   implicit val version: Version = Version.v3
 }

--- a/src/main/scala/com/diffbot/api/scala/Implicits.scala
+++ b/src/main/scala/com/diffbot/api/scala/Implicits.scala
@@ -17,5 +17,5 @@ object Implicits {
   /**
    * The default Diffbot API to use, v2.
    */
-  implicit val version: Version = Version.v2
+  implicit val version: Version = Version.v3
 }


### PR DESCRIPTION
Hello,

This is just a few changes to enable the diffbot-scala-client to use the Version 3 of the Diffbot API.

Am.
